### PR TITLE
Added support for large files on linux; Added error reporting log messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 CC = g++
 
-CFLAGS = -ggdb3
+CFLAGS = -ggdb3 -D_FILE_OFFSET_BITS=64
 
 OBJ = bin/Export2DB.o bin/math_functions.o bin/Node.o bin/Tag.o bin/OSMDocumentParserCallback.o bin/Way.o bin/OSMDocument.o bin/Type.o bin/Class.o bin/Configuration.o bin/ConfigurationParserCallback.o bin/Relation.o bin/XMLParser.o
 
@@ -20,7 +20,7 @@ bin:
 	mkdir -p bin
   
 bin/%.o : src/%.cpp
-	$(CC) -o $@ $(INC_DIRS) -ggdb3 -c $<
+	$(CC) -o $@ $(INC_DIRS) $(CFLAGS) -c $<
 
 clean:
 	rm -rf bin

--- a/src/XMLParser.cpp
+++ b/src/XMLParser.cpp
@@ -19,6 +19,8 @@
  ***************************************************************************/
 
 #include <cstdio> 
+#include <errno.h>
+#include <string.h>
 #include "stdafx.h"
 #include "XMLParser.h"
 
@@ -79,6 +81,8 @@ int XMLParser::Parse( XMLParserCallback& rCallback, const char* chFileName )
     XML_ParserFree(parser);
     fclose(fp);
     ret = 0;
+  }else{
+    fprintf(stderr, "Error opening %s: %s\n", chFileName, strerror(errno));
   }
   return ret; // return = 0 indicating success
 }

--- a/src/osm2pgrouting.cpp
+++ b/src/osm2pgrouting.cpp
@@ -149,7 +149,10 @@ int main(int argc, char* argv[])
 	cout << "Trying to parse config" << endl;
 
 	int ret = parser.Parse( cCallback, cFile.c_str() );
-	if( ret!=0 ) return 1;
+	if( ret!=0 ) {
+		cerr << "Failed to parse config file " << cFile.c_str() << endl;
+		return 1;
+	}
 
 	cout << "Trying to load data" << endl;
 
@@ -159,7 +162,12 @@ int main(int argc, char* argv[])
 	cout << "Trying to parse data" << endl;
 
 	ret = parser.Parse( callback, file.c_str() );
-	if( ret!=0 ) return 1;
+	if( ret!=0 ) {
+		if( ret == 1 )
+			cerr << "Failed to open data file" << endl;
+		cerr << "Failed to parse data file " << file.c_str() << endl;
+		return 1;
+	}
 	
 	cout << "Split ways" << endl;
 


### PR DESCRIPTION
osm2pgrouting did not support reading files >2GB until now. Modified the Makefile to pass _FILE_OFFSET_BITS=64 to make fopen support large files.

Added a bit of extra logging code, which prints errors related to opening the input files.
