### PR TITLE
fix backslash removal of way names

### DIFF
--- a/src/Export2DB.cpp
+++ b/src/Export2DB.cpp
@@ -305,10 +305,10 @@ void Export2DB::exportWays(std::vector<Way*>& ways, Configuration* config)
 	  	if(!way->name.empty())
 	  	{
         std::string escaped_name = way->name;
+        boost::replace_all(escaped_name, "\\", "");
         boost::replace_all(escaped_name, "\t", "\\\t");
         boost::replace_all(escaped_name, "\n", "");
         boost::replace_all(escaped_name, "\r", "");
-        boost::replace_all(escaped_name, "\\", "");
         row_data += escaped_name.substr(0,199);
 	  	}
 	  	row_data += "\n";


### PR DESCRIPTION
Previuosly, tabs didn't actually get escaped
