### PR TITLE
don't print error output when no error occured

### DIFF
--- a/src/Export2DB.cpp
+++ b/src/Export2DB.cpp
@@ -84,7 +84,7 @@ void Export2DB::createTables()
     std::string create_ways("CREATE TABLE " + tables_prefix + "ways (gid integer, class_id integer not null, length double precision, name text, x1 double precision, y1 double precision, x2 double precision, y2 double precision, reverse_cost double precision, rule text, to_cost double precision, maxspeed_forward integer, maxspeed_backward integer, osm_id bigint, priority double precision DEFAULT 1);"
             + " SELECT AddGeometryColumn('" + tables_prefix + "ways','the_geom',4326,'LINESTRING',2);");
 	result = PQexec(mycon, create_ways.c_str());
-	if (PQresultStatus(result) != PGRES_COMMAND_OK)
+	if (PQresultStatus(result) != PGRES_TUPLES_OK)
     {
         std::cerr << PQresultStatus(result);
         std::cerr << "create ways failed: "


### PR DESCRIPTION
The 'create_ways' query is two concatenated commands with the last one being a SELECT query. So check, if that went OK.
