### PR TITLE
Enable only 'version' for ways

### DIFF
--- a/src/Export2DB.cpp
+++ b/src/Export2DB.cpp
@@ -105,7 +105,7 @@ Export2DB::Export2DB(const  po::variables_map &vm)
             " target_osm bigint,"
             " priority double precision DEFAULT 1"
 // Version & timestamp
-	       		// ", version int"
+	       		", version int"
           //   ", timestamp TIMESTAMP WITHOUT TIME ZONE"
         );
         create_relations =std::string(
@@ -630,7 +630,7 @@ void Export2DB::exportWays(const std::vector<Way*> &ways, Configuration *config)
                      " maxspeed_forward, maxspeed_backward,"
                      " priority,"
                      " name"
-                     // ", version"
+                     ", version"
                      // ", timestamp"
                      );
     prepare_table(ways_columns);
@@ -700,8 +700,8 @@ void Export2DB::exportWays(const std::vector<Way*> &ways, Configuration *config)
             boost::replace_all(escaped_name, "\r", "");
             row_data += escaped_name.substr(0,199);
           }
-        // row_data += "\t";
-        // row_data += TO_STR(way->version);
+        row_data += "\t";
+        row_data += TO_STR(way->version);
         // row_data += "\t";
         // row_data += "'" + TO_STR(way->timestamp) + "'";
                 
@@ -749,7 +749,7 @@ void Export2DB::process_section(int64_t count, const std::string &ways_columns) 
     std::string insert_into_ways(
          " INSERT INTO " + addSchema( full_table_name("ways") ) +
           "( " + ways_columns + ", source, target, length_m, cost_s, reverse_cost_s ) "
-         " (SELECT " + ways_columns + ", source, target, length_m, cost_s, reverse_cost_s FROM __ways_temp); ");
+         " (SELECT " + ways_columns + ", source, target, length_m, cost_s, reverse_cost_s, version FROM __ways_temp); ");
     q_result = PQexec(mycon, insert_into_ways.c_str());
     // std::cout << " Inserted " << PQcmdTuples(q_result) << " split ways\n";
     std::cout << "    Ways inserted: " << count << "\n";


### PR DESCRIPTION
Enabled only importing 'version' for ways table.
Doesn't work, **ways** table comes out empty

Console log while importing the same as earlier sample into a blank new db

Command used from build directory
`./osm2pgrouting -c ../mapconfig.xml -f ~/Desktop/sample.osm --addnodes --clean -h 192.168.0.37 -d sample2 -U postgres -W postgres`

```
Opening data file: /home/aakash/Desktop/sample.osm
    Parsing data

Spliting ways

Dropping tables...
NOTICE:  table "ways" does not exist, skipping
NOTICE:  table "ways_vertices_pgr" does not exist, skipping
NOTICE:  table "relations_ways" does not exist, skipping
Creating tables...
Creating 'ways_vertices_pgr': OK
   Adding Geometry: Creating 'ways': OK
   Adding Geometry: Creating 'relations_ways': OK
Creating 'osm_nodes': OK
   Adding Geometry: Creating 'osm_relations': OK
Creating 'osm_way_tags': OK
Creating 'osm_way_types': OK
Creating 'osm_way_classes': OK
Adding auxiliary tables to database...
    Processing 2642285 nodes:  Inserted: 2642285
    Processing 4 way types:  Inserted 4 way types
    Processing way's classes:  Inserted 36 way's classes
    Processing way's relations:  Inserted: 57260way's relations
    Processing way's tags:  Inserted 128982 way's tags
    Processing 120514 ways:
Vertices inserted 79988    Ways inserted: 100000
Vertices inserted 9724    Ways inserted: 120514
Creating topology...
#########################
size of streets: 59832
size of split ways : 120514
Execution started at: Tue Aug 30 10:47:14 2016
Execution ended at:   Tue Aug 30 10:53:50 2016
Elapsed time: 395.677 Seconds.
User CPU time: -> 44.57 seconds
```