### PR TITLE
Fix spelling errors.

### DIFF
--- a/src/database/Export2DB.cpp
+++ b/src/database/Export2DB.cpp
@@ -167,16 +167,16 @@ void Export2DB::dropTables() const {
         pqxx::work Xaction(db_conn);
 
         Xaction.exec(ways().drop());
-        std::cout << "TABLE: " << ways().addSchema() << " droped ... OK.\n";
+        std::cout << "TABLE: " << ways().addSchema() << " dropped ... OK.\n";
 
         Xaction.exec(vertices().drop());
-        std::cout << "TABLE: " << vertices().addSchema() << " droped ... OK.\n";
+        std::cout << "TABLE: " << vertices().addSchema() << " dropped ... OK.\n";
 
         Xaction.exec(pois().drop());
-        std::cout << "TABLE: " << pois().addSchema() << " droped ... OK.\n";
+        std::cout << "TABLE: " << pois().addSchema() << " dropped ... OK.\n";
 
         Xaction.exec(configuration().drop());
-        std::cout << "TABLE: " << configuration().addSchema() << " droped ... OK.\n";
+        std::cout << "TABLE: " << configuration().addSchema() << " dropped ... OK.\n";
 
         Xaction.commit();
     } catch (const std::exception &e) {
@@ -188,13 +188,13 @@ void Export2DB::dropTables() const {
         pqxx::connection db_conn(conninf);
         pqxx::work Xaction(db_conn);
         Xaction.exec(osm_nodes().drop());
-        std::cout << "TABLE: " << osm_nodes().addSchema() << " droped ... OK.\n";
+        std::cout << "TABLE: " << osm_nodes().addSchema() << " dropped ... OK.\n";
 
         Xaction.exec(osm_ways().drop());
-        std::cout << "TABLE: " << osm_ways().addSchema() << " droped ... OK.\n";
+        std::cout << "TABLE: " << osm_ways().addSchema() << " dropped ... OK.\n";
 
         Xaction.exec(osm_relations().drop());
-        std::cout << "TABLE: " << osm_relations().addSchema() << " droped ... OK.\n";
+        std::cout << "TABLE: " << osm_relations().addSchema() << " dropped ... OK.\n";
 
         Xaction.commit();
     } catch (const std::exception &e) {

--- a/src/osm_elements/osm2pgrouting.cpp
+++ b/src/osm_elements/osm2pgrouting.cpp
@@ -133,7 +133,7 @@ int main(int argc, char* argv[]) {
                 << endl;
             pqxx::connection C(connection_str);
             if (C.is_open()) {
-                cout << "database connection successfull: " << C.dbname() << endl;
+                cout << "database connection successful: " << C.dbname() << endl;
             } else {
                 cout << "Can't open database" << endl;
                 return 1;


### PR DESCRIPTION
The lintian QA tool reported a couple of spelling errors for the Debian package build of 2.3.0:

 * droped      -> dropped
 * successfull -> successful