### PR TITLE
Fixed print progress info and Prevent unused flags (addways and addrelations) from appearing in "Command Line Configuration" 

### DIFF
--- a/include/utilities/print_progress.h
+++ b/include/utilities/print_progress.h
@@ -47,6 +47,6 @@ print_progress(T1 wantProgress, T2 currentProgress) {
     std::cout << "\r"
         << bar
         << " (" << static_cast<int>(100 * percent) << "%)"
-        << " Total porcessed: " << currentProgress << std::flush;
+        << " Total processed: " << currentProgress << std::flush;
 }
 #endif  // SRC_PRINT_PROGRESS_H_

--- a/src/utilities/prog_options.cpp
+++ b/src/utilities/prog_options.cpp
@@ -104,9 +104,9 @@ process_command_line(po::variables_map &vm) {
     std::cout << (vm.count("clean")? "D" : "Don't d") << "rop tables\n";
     std::cout << (vm.count("no-index")? "D" : "Don't c") << "reate indexes\n";
     std::cout << (vm.count("addnodes")? "A" : "Don't a") << "dd OSM nodes\n";
+#if 0
     std::cout << (vm.count("addways")? "A" : "Don't a") << "dd OSM ways\n";
     std::cout << (vm.count("addrelations")? "A" : "Don't a") << "dd OSM relations\n";
-#if 0
     std::cout << (vm.count("fork")? "F" : "Don't f") << "ork\n";
 #endif
     std::cout << "***************************************************\n";


### PR DESCRIPTION
Hi,

1 - Fixed print progress info in ```print_progress()``` function.

2 - To prevent unused flags (addways and addrelations) from appearing in "Command Line Configuration" print info, I included it in preprocessor directivein ```process_command_line()``` function. If you use addnodes flag osm_ways and osm_relations are populated but in print info appears a contradictory message. You can see "Command Line Configuration" print info before and after:

Before:
```
***************************************************
           COMMAND LINE CONFIGURATION             *
***************************************************
Filename = /tmp/output_data.osm
Configuration file = /usr/src/app/itinera/mapconfig/mapconfig.xml
host = localhost
port = 5432
dbname = routing
username = routing_admin
password = routing
schema= bcn_tags_demo3
prefix = 
suffix = 
Don't Install postgis if not found
Drop tables
Don't create indexes
Add OSM nodes
Don't add OSM ways
Don't add OSM relations
***************************************************
```

After:
```
***************************************************
           COMMAND LINE CONFIGURATION             *
***************************************************
Filename = /tmp/output_data.osm
Configuration file = /usr/src/app/itinera/mapconfig/mapconfig.xml
host = localhost
port = 5432
dbname = routing
username = routing_admin
password = routing
schema= bcn_tags_demo3
prefix = 
suffix = 
Don't Install postgis if not found
Drop tables
Don't create indexes
Add OSM nodes
***************************************************
```

Thanks,
Cayetano