### PR TITLE
Fixes #191

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,10 @@
-osm2pgRouting 2.3.0
+osm2pgRouting 2.3.2
+
+* Fix: Only on linux: use the wc command to count lines
+* Fix: the `osm_<tables>` are created only when addnodes flag is on
+* Fix: removed unused flag of the command line
+
+osm2pgRouting 2.3.1
 
 * Fix: When keys have spaces
 * Fix: Generating relations

--- a/src/database/Export2DB.cpp
+++ b/src/database/Export2DB.cpp
@@ -135,6 +135,7 @@ void Export2DB::createTables() const {
         exit(1);
     }
 
+    if (m_vm.count("addnodes")) {
     try {
         pqxx::connection db_conn(conninf);
         pqxx::work Xaction(db_conn);
@@ -155,6 +156,7 @@ void Export2DB::createTables() const {
         std::cerr <<  "\n" << e.what() << std::endl;
         std::cerr <<  "WARNING: could not create osm-*  tables" << std::endl;
         std::cerr <<  "   Insertions on osm_* tables are going to be ignored" << std::endl;
+    }
     }
 }
 

--- a/src/database/osm_nodes_config.cpp
+++ b/src/database/osm_nodes_config.cpp
@@ -44,10 +44,10 @@ Tables::osm_nodes_config() const {
             /* standard column creation string */
             std::string(
                 " osm_id bigint PRIMARY KEY"
-                + (m_vm.count("attributes") ?
+                + (m_vm.count("attributes") && m_vm.count("addnodes") ?
                     (std::string(", attributes hstore"))
                     : "")
-                + (m_vm.count("tags") ?
+                + (m_vm.count("tags")  && m_vm.count("addnodes") ?
                     (std::string(", tags hstore"))
 #if 0
                     (std::string(", tags ") + (m_vm.count("hstore") ? "hstore" : "json"))

--- a/src/database/osm_relations_config.cpp
+++ b/src/database/osm_relations_config.cpp
@@ -45,10 +45,10 @@ Tables::osm_relations_config() const {
             std::string(
                 " osm_id bigint PRIMARY KEY"
                 " , members hstore"
-                + (m_vm.count("attributes") ?
+                + (m_vm.count("attributes")  && m_vm.count("addnodes") ?
                     (std::string(", attributes hstore"))
                     : "")
-                + (m_vm.count("tags") ?
+                + (m_vm.count("tags")  && m_vm.count("addnodes")?
                     (std::string(", tags hstore"))
                     : "")
                 ),

--- a/src/database/osm_ways_config.cpp
+++ b/src/database/osm_ways_config.cpp
@@ -44,11 +44,11 @@ Tables::osm_ways_config() const {
             /* standard column creation string */
             std::string(
                 " osm_id bigint PRIMARY KEY"
-                " , members hstore"
-                + (m_vm.count("attributes") ?
-                    (std::string(", attributes hstore"))
+                //" , members hstore"
+                + (m_vm.count("attributes")  && m_vm.count("addnodes") ?
+                    (std::string(", attributes hstore")) 
                     : "")
-                + (m_vm.count("tags") ?
+                + (m_vm.count("tags")  && m_vm.count("addnodes") ?
                     (std::string(", tags hstore"))
 #if 0
                     (std::string(", tags ") + (m_vm.count("hstore") ? "hstore" : "json"))

--- a/src/osm_elements/osm2pgrouting.cpp
+++ b/src/osm_elements/osm2pgrouting.cpp
@@ -163,7 +163,7 @@ int main(int argc, char* argv[]) {
             std::cout << "   HINT: CREATE EXTENSION postGIS\n";
             return 1;
         }
-        if ((vm.count("attributes") || vm.count("tags"))
+        if ((vm.count("attributes") || vm.count("tags") || vm.count("addnodes"))
                 && !dbConnection.has_extension("hstore")) {
             std::cout << "ERROR: hstore not found\n";
             std::cout << "   HINT: CREATE EXTENSION hstore\n";

--- a/src/osm_elements/osm2pgrouting.cpp
+++ b/src/osm_elements/osm2pgrouting.cpp
@@ -41,6 +41,7 @@
 #include "utilities/handle_pgpass.h"
 #include "utilities/prog_options.h"
 
+#if defined(__linux__)
 static
 size_t lines_in_file(const std::string file_name) {
     FILE *in;
@@ -67,6 +68,7 @@ size_t lines_in_file(const std::string file_name) {
         exit(1);
     }
 }
+#endif
 
 
 int main(int argc, char* argv[]) {
@@ -201,6 +203,7 @@ int main(int argc, char* argv[]) {
         std::cout << "  - Done \n";
 
 
+#if defined(__linux__)
         std::cout << "Counting lines ...\n";
         auto total_lines = lines_in_file(dataFile);
         std::cout << "  - Done \n";
@@ -210,6 +213,9 @@ int main(int argc, char* argv[]) {
             << "\ttotal lines: "
             << total_lines
             << endl;
+#else
+        size_t total_lines = 0;
+#endif
         osm2pgr::OSMDocument document(config, vm, dbConnection, total_lines);
         osm2pgr::OSMDocumentParserCallback callback(document);
 

--- a/src/utilities/prog_options.cpp
+++ b/src/utilities/prog_options.cpp
@@ -51,7 +51,9 @@ void get_option_description(po::options_description &od_desc) {
         ("schema", po::value<std::string>()->default_value(""), "Database schema to put tables.\n  blank:\t defaults to default schema dictated by PostgreSQL search_path.")
         ("prefix", po::value<std::string>()->default_value(""), "Prefix added at the beginning of the table names.")
         ("suffix", po::value<std::string>()->default_value(""), "Suffix added at the end of the table names.")
+#if 0
         ("postgis", "Install postgis if not found.")  // TODO(vicky) remove before realesing
+#endif
         ("addnodes", "Import the osm_nodes, osm_ways & osm_relations tables.")
         ("attributes", "Include attributes information.")
         ("tags", "Include tag information.")
@@ -100,7 +102,9 @@ process_command_line(po::variables_map &vm) {
     std::cout << "schema= " << vm["schema"].as<std::string>() << "\n";
     std::cout << "prefix = " << vm["prefix"].as<std::string>() << "\n";
     std::cout << "suffix = " << vm["suffix"].as<std::string>() << "\n";
+#if 0
     std::cout << (vm.count("postgis")? "I" : "Don't I") << "nstall postgis if not found\n";
+#endif
     std::cout << (vm.count("clean")? "D" : "Don't d") << "rop tables\n";
     std::cout << (vm.count("no-index")? "D" : "Don't c") << "reate indexes\n";
     std::cout << (vm.count("addnodes")? "A" : "Don't a") << "dd OSM nodes\n";


### PR DESCRIPTION
Fix for issue #191

* Fix: Only on linux: use the wc command to count lines
* Fix: the `osm_<tables>` are created only when addnodes flag is on
* Fix: removed unused flag of the command line
