### PR TITLE
Solved regression on 2.3.2: fixed hstore refs handling

### DIFF
--- a/src/database/osm_ways_config.cpp
+++ b/src/database/osm_ways_config.cpp
@@ -26,7 +26,7 @@ namespace osm2pgr {
 
 /*
  * configuring TABLE osm_ways
- */ 
+ */
 
 
 Table
@@ -44,9 +44,9 @@ Tables::osm_ways_config() const {
             /* standard column creation string */
             std::string(
                 " osm_id bigint PRIMARY KEY"
-                //" , members hstore"
+                " , members hstore"
                 + (m_vm.count("attributes")  && m_vm.count("addnodes") ?
-                    (std::string(", attributes hstore")) 
+                    (std::string(", attributes hstore"))
                     : "")
                 + (m_vm.count("tags")  && m_vm.count("addnodes") ?
                     (std::string(", tags hstore"))


### PR DESCRIPTION
Hi,

Version 2.3.2 adds a regression on ways ref handling. 

OSM file to reproduce this error (downloaded with Overpass API and it is the same used to solve #189 ):
https://drive.google.com/file/d/0B8PuZrBkyPBuVk9KUE93SVZqWVE/view?usp=sharing

This PR fixes this error (you can see how it raises an error with nd ref=423390080; below shell output I paste OSM file for this way): 

```
***************************************************
           COMMAND LINE CONFIGURATION             *
***************************************************
Filename = /tmp/output_data.osm
Configuration file = /usr/src/app/itinera/mapconfig/mapconfig.xml
host = localhost
port = 5432
dbname = routing
username = routing_admin
password = routing
schema= bcn_tags_demo5
prefix = 
suffix = 
Drop tables
Don't create indexes
Add OSM nodes
***************************************************
Testing database connection: routing
database connection successful: routing
Connecting to the database
connection success

Dropping tables...
TABLE: bcn_tags_demo5.ways dropped ... OK.
TABLE: bcn_tags_demo5.ways_vertices_pgr dropped ... OK.
TABLE: bcn_tags_demo5.pointsofinterest dropped ... OK.
TABLE: bcn_tags_demo5.configuration dropped ... OK.
TABLE: bcn_tags_demo5.osm_nodes dropped ... OK.
TABLE: bcn_tags_demo5.osm_ways dropped ... OK.
TABLE: bcn_tags_demo5.osm_relations dropped ... OK.

Creating tables...
TABLE: bcn_tags_demo5.ways_vertices_pgr created ... OK.
TABLE: bcn_tags_demo5.ways created ... OK.
TABLE: bcn_tags_demo5.pointsofinterest created ... OK.
TABLE: bcn_tags_demo5.configuration created ... OK.
TABLE: bcn_tags_demo5.osm_nodes created ... OK.
TABLE: bcn_tags_demo5.osm_ways created ... OK.
TABLE: bcn_tags_demo5.osm_relations created ... OK.
Opening configuration file: /usr/src/app/itinera/mapconfig/mapconfig.xml
    Parsing configuration

Exporting configuration ...
  - Done 
Counting lines ...
  - Done 
Opening data file: /tmp/output_data.osm	total lines: 5102655
    Parsing data

Current osm_nodes:	1580000
Final osm_nodes:	1587311
Current osm_ways:	20000
*****ERROR HERE:
 2642104	423390080=>"type=>nd",4634913=>"type=>nd",1344107987=>"type=>nd",1344107951=>"type=>nd",423381040=>"type=>nd",4997970022=>"type=>nd",1100715937=>"type=>nd",423211741=>"type=>nd",1344107998=>"type=>nd",423373731=>"type=>nd",1344107970=>"type=>nd",423211742=>"type=>nd",423363685=>"type=>nd" 	\N	\N	LGV de Villeneuve-Saint-Georges à Moisenay	"changeset" => "50625565","id" => "2642104","timestamp" => "2017-07-27T17:17:24Z","uid" => "22165","user" => "Denis_Helfer","version" => "27" 	"description" => "LGV Interconnexion Est","electrified" => "contact_line","frequency" => "50","gauge" => "1435","highspeed" => "yes","importance" => "national","maxspeed" => "300","name" => "LGV de Villeneuve-Saint-Georges à Moisenay","operator" => "SNCF Réseau","passenger_lines" => "2","railway" => "rail","railway:bidirectional" => "regular","railway:preferred_direction" => "forward","railway:radio" => "analogue","railway:track_ref" => "2","railway:traffic_mode" => "passenger","railway:tvm" => "yes","ref" => "752100","start_date" => "1996","usage" => "main","voltage" => "25000" 	srid=4326;LINESTRING(2.7278180 48.6758974, 2.7275471 48.6766724, 2.7272612 48.6774964, 2.7269765 48.6783234, 2.7266670 48.6791465, 2.7265258 48.6794977, 2.7263535 48.6799040, 2.7262288 48.6801939, 2.7259424 48.6808090, 2.7256293 48.6814221, 2.7253313 48.6819692, 2.7250634 48.6824360, 2.7246254 48.6831599) 

******
*****ERROR HERE:
 2953908	1856859335=>"type=>nd",2510486558=>"type=>nd",3012001656=>"type=>nd" 	\N	\N	Marseille-Saint-Charles	"changeset" => "42535479","id" => "2953908","timestamp" => "2016-09-30T07:36:52Z","uid" => "4023601","user" => "A FRISETTI","version" => "49" 	"covered" => "yes","electrified" => "contact_line","frequency" => "0","gauge" => "1435","importance" => "national","level" => "0","maxspeed" => "30","name" => "Marseille-Saint-Charles","operator" => "SNCF Réseau","passenger_lines" => "16","railway" => "rail","railway:bidirectional" => "regular","railway:kvb" => "yes","railway:preferred_direction" => "both","railway:radio" => "analogue","railway:track_ref" => "K","railway:traffic_mode" => "mixed","ref" => "830000","start_date" => "1848","usage" => "main","voltage" => "1500" 	srid=4326;LINESTRING(5.3802841 43.3032847, 5.3806444 43.3034743, 5.3806955 43.3035012) 

******
*****ERROR HERE:

(...........)
```

You can see the nd ref in this osm file (error on nd ref=423390080):

```  
<way id="2642104" version="27" timestamp="2017-07-27T17:17:24Z" changeset="50625565" uid="22165" user="Denis_Helfer">
    <nd ref="423390080"/>
    <nd ref="4634913"/>
    <nd ref="1344107987"/>
    <nd ref="1344107951"/>
    <nd ref="423381040"/>
    <nd ref="4997970022"/>
    <nd ref="1100715937"/>
    <nd ref="423211741"/>
    <nd ref="1344107998"/>
    <nd ref="423373731"/>
    <nd ref="1344107970"/>
    <nd ref="423211742"/>
    <nd ref="423363685"/>
    <tag k="description" v="LGV Interconnexion Est"/>
    <tag k="electrified" v="contact_line"/>
    <tag k="frequency" v="50"/>
    <tag k="gauge" v="1435"/>
    <tag k="highspeed" v="yes"/>
    <tag k="importance" v="national"/>
    <tag k="maxspeed" v="300"/>
    <tag k="name" v="LGV de Villeneuve-Saint-Georges à Moisenay"/>
    <tag k="operator" v="SNCF Réseau"/>
    <tag k="passenger_lines" v="2"/>
    <tag k="railway" v="rail"/>
    <tag k="railway:bidirectional" v="regular"/>
    <tag k="railway:preferred_direction" v="forward"/>
    <tag k="railway:radio" v="analogue"/>
    <tag k="railway:track_ref" v="2"/>
    <tag k="railway:traffic_mode" v="passenger"/>
    <tag k="railway:tvm" v="yes"/>
    <tag k="ref" v="752100"/>
    <tag k="start_date" v="1996"/>
    <tag k="usage" v="main"/>
    <tag k="voltage" v="25000"/>
  </way>
```

Thanks,

Cayetano
