### PR TITLE
Fixed wrong assumption in implied_oneWay() function

### DIFF
--- a/src/osm_elements/Way.cpp
+++ b/src/osm_elements/Way.cpp
@@ -40,7 +40,7 @@ Way::Way(const char **atts) :
     Element(atts),
     m_maxspeed_forward(-1),
     m_maxspeed_backward(-1),
-    m_oneWay("UNKNOWN") { 
+    m_oneWay("UNKNOWN") {
     }
 
 Tag
@@ -208,13 +208,6 @@ Way::implied_oneWay(const Tag &tag) {
         return;
     }
 
-    if (key == "highway"
-            && (value == "primary"
-                || value == "secondary"
-                || value == "tertiary")) {
-        m_oneWay = "NO";
-        return;
-    }
 }
 
 #if 0
@@ -332,7 +325,7 @@ Way::members_str() const {
     std::string node_list("");
     for (const auto &node_id : m_node_ids) {
         node_list += boost::lexical_cast<std::string>(node_id) + "=>\"type=>nd\",";
-    } 
+    }
     node_list[node_list.size() -1] = ' ';
 
     return node_list;
@@ -363,4 +356,3 @@ std::ostream& operator<<(std::ostream &os, const Way &way) {
 
 
 }  // namespace osm2pgr
-


### PR DESCRIPTION
Hi,

I fixed a wrong assumption(*) in ```implied_oneWay()``` function (see below OSM info about it):

```
if (key == "highway"
            && (value == "primary"
                || value == "secondary"
                || value == "tertiary")) {
        m_oneWay = "NO";
        return;
    }
```
(*) Following OSM wiki, oneway in these key/value combinations can be equal to yes or no:
- http://wiki.openstreetmap.org/wiki/Tag:highway%3Dprimary
- http://wiki.openstreetmap.org/wiki/Tag:highway%3Dsecondary
- http://wiki.openstreetmap.org/wiki/Tag:highway%3Dtertiary

This assumption makes that a lot of roads with oneway=yes changes automatically to oneway=no (and this is a problem in PgRouting). You can see this example:

Original info (OSM):
![image](https://user-images.githubusercontent.com/7315379/32400797-14139e6c-c105-11e7-9498-75a40dd9ea76.png)

New info processed with osm2pgrouting:
![image](https://user-images.githubusercontent.com/7315379/32400808-3f29df9e-c105-11e7-9fb6-d9bab6d8fde0.png)

Thanks,

Cayetano