### PR TITLE
osmium tool - create schema in restrictions sql script

### DIFF
--- a/tools/osmium/restrictions.sql
+++ b/tools/osmium/restrictions.sql
@@ -23,6 +23,8 @@ SET default_with_oids = false;
 -- Name: osm_restrictions; Type: TABLE; Schema: public; Owner: -; Tablespace: 
 --
 
+CREATE SCHEMA IF NOT EXISTS foo;
+
 CREATE TABLE IF NOT EXISTS foo.osm_restrictions(
     osm_id BIGINT PRIMARY KEY,
     osm_from    BIGINT[],


### PR DESCRIPTION
To avoid a db schema fail when you are running SQL script with getrestrictions CLI.