### PR TITLE
osm_elements - fixed boolean assignment with boost::lexical_cast

### DIFF
--- a/src/osm_elements/osm2pgrouting.cpp
+++ b/src/osm_elements/osm2pgrouting.cpp
@@ -98,7 +98,7 @@ int main(int argc, char* argv[]) {
         }
 
         if (vm.count("version")) {
-            std::cout << "This is osm2pgrouting Version 2.3.3\n";
+            std::cout << "This is osm2pgrouting Version 2.3.4\n";
             return 0;
         }
 

--- a/src/osm_elements/osm_element.cpp
+++ b/src/osm_elements/osm_element.cpp
@@ -38,7 +38,7 @@ Element::Element(const char **atts) :
                 m_osm_id = boost::lexical_cast<int64_t>(value);
             }
             if (name == "visible") {
-                m_visible = boost::lexical_cast<bool>(value);
+                m_visible = (value == "true")? true : false;
             }
            m_attributes[name] = value;
         }


### PR DESCRIPTION
Fixing #218 

This error is raising because a bad boolean assignment using boost::lexical_cast while osm2pgrouting is parsing OSM elements. I reproduced the error with my own dataset too.