### PR TITLE
 fixed zero division error when max_speed = 0

### DIFF
--- a/src/database/Export2DB.cpp
+++ b/src/database/Export2DB.cpp
@@ -377,7 +377,7 @@ void Export2DB::fill_source_target(
             "           WHEN one_way = 1 THEN -ST_length(geography(ST_Transform(the_geom, 4326))) / (maxspeed_backward::float * 5.0 / 18.0)"
             "           ELSE ST_length(geography(ST_Transform(the_geom, 4326))) / (maxspeed_backward::float * 5.0 / 18.0)"
             "             END "
-            " WHERE length_m IS NULL AND maxspeed_forward != 0;");
+            " WHERE length_m IS NULL AND maxspeed_backward !=0 AND maxspeed_forward != 0;");
     Xaction.exec(sql3);
 }
 


### PR DESCRIPTION
This PR fixes a zero division error when max_speed = 0. When a way from OSM has max_speed_backward or max_speed_forward equal to zero, we assume that cost or reverse cost must be NULL (it is impossible to have cost without speed; this is a OSM problem and must be fixed in OSM side; it is not a osm2pgrouting problem).