### PR TITLE
Switch to a more inclusive check for nullptr definition

### DIFF
--- a/include/parser/ConfigurationParserCallback.h
+++ b/include/parser/ConfigurationParserCallback.h
@@ -23,9 +23,7 @@
 #define SRC_CONFIGURATIONPARSERCALLBACK_H_
 #pragma once
 
-#if __GNUC__ > 4 || \
-                    (__GNUC__ == 4 && (__GNUC_MINOR__ >= 6))
-#else
+#ifdef BOOST_NO_CXX11_NULLPTR
 #define nullptr NULL
 #endif
 

--- a/include/parser/OSMDocumentParserCallback.h
+++ b/include/parser/OSMDocumentParserCallback.h
@@ -23,9 +23,7 @@
 #define SRC_OSMDOCUMENTPARSERCALLBACK_H_
 #pragma once
 
-#if __GNUC__ > 4 || \
-            (__GNUC__ == 4 && (__GNUC_MINOR__ >= 6))
-#else
+#ifdef BOOST_NO_CXX11_NULLPTR
 #define nullptr NULL
 #endif
 


### PR DESCRIPTION
This avoids redefining `nullptr` on platforms where it is defined, such as on macOS using recent versions of clang.

I've confirmed that this fixes compilation on macOS 10.13 using Xcode 9.3.

cc @ilovezfs

Fixes #227.