### PR TITLE
implied_oneWay - oneway restriction only for roundabout and motorway

### DIFF
--- a/src/osm_elements/Way.cpp
+++ b/src/osm_elements/Way.cpp
@@ -201,9 +201,7 @@ Way::implied_oneWay(const Tag &tag) {
     if (m_oneWay != "UNKNOWN") return;
 
     if ((key == "junction" && value == "roundabout")
-            || (key == "highway"
-                && (value == "motorway"
-                    || value == "trunk") )) {
+            || (key == "highway" && value == "motorway")) {
         m_oneWay = "YES";
         return;
     }


### PR DESCRIPTION
Fixing this issue: https://github.com/pgRouting/osm2pgrouting/issues/240