### PR TITLE
add missing include for std::transform

### DIFF
--- a/src/osm_elements/osm_tag.cpp
+++ b/src/osm_elements/osm_tag.cpp
@@ -20,6 +20,7 @@
 
 
 #include "osm_elements/osm_tag.h"
+#include <algorithm>
 #include <string>
 
 namespace osm2pgr {


### PR DESCRIPTION
Changes proposed in this pull request:
- Add `algorithm` for `std::transform` as build can fail if it isn't indirectly included by standard library. Seen in Homebrew for Linux (Ubuntu 22.04/GCC-11) - ref https://github.com/Homebrew/homebrew-core/pull/170200


@pgRouting/admins
