### PR TITLE
Bump minimum required CMake version to 3.10 to fix failure with 4.x.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 if ( ${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR} )
     message(FATAL_ERROR "In-source builds not allowed.


### PR DESCRIPTION
Fixes: #312 

3.10 is chosen because 3.5 is also deprecated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Raised the minimum required CMake version to 3.10 for building the project.
  * Builds using older CMake versions will fail at configuration; please upgrade your build tools to continue building from source.
  * No changes to application functionality or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->