### PR TITLE
Escape backslashes when building tab-separated row

### DIFF
--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "boost/algorithm/string/replace.hpp"
 
 
 std::string 
@@ -39,6 +40,7 @@ tab_separated(const std::vector<std::string> &columns) {
         if (column.empty() || column == "") {
             result += "\\N\t";
         } else {
+            boost::replace_all(column, "\\", "\\\\");
             result += column + "\t";
         }
     }                       


### PR DESCRIPTION
Thanks for making and maintaining this package, it's really excellent! I have been running into the issue mentioned in https://github.com/pgRouting/osm2pgrouting/issues/259#issuecomment-2652779188 where a name of `"\"` causes the process to fail with:

```
ERROR:  extra data after last expected column
CONTEXT:  COPY __ways17535, line 1: " 112       8720801 50      50      0       UNKNOWN 0       0.032828469505751391    -83.6166172     42.2295873      -83.63609       42.2560168   6247..."
```

I noticed that in the past there was escaping of backslashes (https://github.com/pgRouting/osm2pgrouting/commit/a120fc23c3c3ef785d44a7a8e4f2f3c2124da95f), but I wasn't able to track down the removal, so I've taken a similar approach here. I've included a minimal test OSM file below that fails without the patch and succeeds with it. It's based on a much larger file that fails and succeeds in the same way.

<details>
<summary>Test File</summary>

```
<?xml version='1.0' encoding='UTF-8'?>
<osm version="0.6">
	<bounds minlat="42.187151" minlon="-83.699906" maxlat="42.300306" maxlon="-83.553524"/>
	<node id="62472359" lat="42.2295873" lon="-83.6166172" version="7" timestamp="2023-08-17T19:02:05Z" changeset="0"/>
	<node id="62472289" lat="42.2559569" lon="-83.6361373" version="4" timestamp="2025-02-15T13:25:01Z" changeset="0"/>
	<node id="4714375469" lat="42.2560168" lon="-83.63609" version="2" timestamp="2025-02-15T13:25:01Z" changeset="0"/>
	<node id="2169047981" lat="42.2299107" lon="-83.6163898" version="1" timestamp="2013-02-23T16:32:23Z" changeset="0"/>
	<way id="8720801" version="4" timestamp="2025-02-15T13:25:01Z" changeset="0">
		<nd ref="62472289"/>
		<nd ref="4714375469"/>
		<tag k="name" v="\"/>
		<tag k="highway" v="service"/>
	</way>
	<way id="8720804" version="7" timestamp="2018-09-06T20:44:47Z" changeset="0">
		<nd ref="62472359"/>
		<nd ref="2169047981"/>
		<tag k="name" v="a\b"/>
		<tag k="highway" v="motorway_link"/>
	</way>
</osm>
```

</details>

Changes proposed in this pull request:
- Escape backslashes when building tab-separated row

@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed improper handling of backslash characters in tab-separated data output to ensure backslashes are correctly escaped during data export, preventing formatting issues and data loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->