### PR TITLE
Escape backslashes when building tab-separated row

### DIFF
--- a/src/utilities/utilities.cpp
+++ b/src/utilities/utilities.cpp
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "boost/algorithm/string/replace.hpp"
 
 
 std::string 
@@ -39,6 +40,7 @@ tab_separated(const std::vector<std::string> &columns) {
         if (column.empty() || column == "") {
             result += "\\N\t";
         } else {
+            boost::replace_all(column, "\\", "\\\\");
             result += column + "\t";
         }
     }                       


### PR DESCRIPTION
(cherry picked from commit 798d8ecb157fdc57b9a61e6a9378a7a60833b72c)

The pr #317 was made with the old code, and all tests were failing


@pgRouting/admins


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of backslashes in tab-separated data exports to ensure proper escaping and preserve data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->